### PR TITLE
Retrieve entire response from http request

### DIFF
--- a/lib/minutedock.js
+++ b/lib/minutedock.js
@@ -198,7 +198,7 @@ Minutedock.prototype.request = function (path, method, form_data, callback) {
     var req = https.request(options, function (res) {
         var json = '';
         res.on('data',function (chunk) {
-            json = chunk.toString();
+            json += chunk.toString();
         }).on('end', function () {
                 if (res.statusCode != 200) {
                     console.error('MinuteDock API error: ' + res.statusCode + ' ' + options.path);


### PR DESCRIPTION
For larger responses (eg contact list), this was returning only the final chunk of json instead of the entire response body.